### PR TITLE
updates reference to caret svg in base repo

### DIFF
--- a/docs/_layouts/api.html
+++ b/docs/_layouts/api.html
@@ -42,7 +42,7 @@ layout: api-header
           {% if part.name %}
             <dt class="js-accordion__header Docs-subnav-title" data-accordion-opened="true">
                 {{ part.name | escape }}
-                {% svg assets/svg/carrot-down.svg %}
+                {% svg assets/svg/caret.svg %}
             </dt>
           {% endif %}
 


### PR DESCRIPTION
Hi @milas @hyu,
please review the following changes:

- rename carrot to caret, so it will reference the correct updated svg in the base repository